### PR TITLE
Replace pkg_resources with Importliberalisierungen_metadata

### DIFF
--- a/.github/workflows/install_doctest_lint_typecheck.yml
+++ b/.github/workflows/install_doctest_lint_typecheck.yml
@@ -76,5 +76,6 @@ jobs:
       - name: mypy
         run: |
           pip install numpy  # for the typing stubs
+          pip install importlib_metadata  # for the typing stubs
           python -m pip install pandas-stubs types-setuptools 
           mypy ncls

--- a/ncls/__init__.py
+++ b/ncls/__init__.py
@@ -1,7 +1,7 @@
+import importlib_metadata
 import numpy as np
-import pkg_resources
 
-__version__ = pkg_resources.get_distribution("ncls").version
+__version__ = importlib_metadata.version("ncls")
 
 from ncls.src.ncls import NCLS64  # type: ignore
 from ncls.src.ncls32 import NCLS32  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 keywords = ["ncls", "interval-tree", "genomics"]
-dependencies = ["numpy"]
+dependencies = ["numpy", "importlib_metadata"]
 
 [project.optional-dependencies]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]


### PR DESCRIPTION
Hi,

first of all, thanks for this great library. I just ran into this warning all the time about pkg_resources being deprecated when in favour of [importlib.metadata](https://setuptools.pypa.io/en/latest/pkg_resources.html).

In this pull request I replaces pas_resources with importlib_metadata: https://docs.python.org/3/library/importlib.metadata.html , this is a back port for Importlib.metadata which is only in the standard library since python 3.8. By explicitly using importlib_metadata, older versions of python 3 are also still supported by NCLS. An alternative would be for NCLS to stop supporting python versions older than 3.8 and use the importlib.metadata from the standard library.