### PR TITLE
bump cibuildwheel to build a py312 wheel

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yml
+++ b/.github/workflows/build_and_upload_wheels.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.16.2
 
       - uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ncls"
-version = "0.0.68"
+version = "0.0.69"
 description = "A fast interval tree-like implementation in C, wrapped for the Python ecosystem."
 readme = "README.md"
 authors = [{ name = "Endre Bakken Stovner", email = "endbak@pm.me" }]


### PR DESCRIPTION
Love this package! cibuildwheel release [2.16.2](https://github.com/pypa/cibuildwheel/releases/tag/v2.16.2) added support for the recently released python 3.12.0. Can we get a bump of cibuildwheel to add a python 3.12 wheel for this? Hopefully thats enough!