### PR TITLE
Include time.h explicitly

### DIFF
--- a/ncls/src/default.h
+++ b/ncls/src/default.h
@@ -27,6 +27,7 @@
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
+#include <time.h>
 
 #if defined(__STDC__) || defined(__ANSI_CPP__)  /*###################*/
 #define STRINGIFY(NAME) # NAME


### PR DESCRIPTION
## Pull Request Description

This pull request addresses a build issue related to the use of `clock_t` and `CLOCKS_PER_SEC` in the `find_intervals_stack` functions, which appear in the following files:

- [`fintervaldb.c` (Lines 1196-1200)](https://github.com/pyranges/ncls/blob/e3503a6b1b7fa80fb2571d9446a8c2dc80c0f4ea/ncls/src/fintervaldb.c#L1184-L1244)
- [`intervaldb.c` (Lines 1220-1224)](https://github.com/pyranges/ncls/blob/e3503a6b1b7fa80fb2571d9446a8c2dc80c0f4ea/ncls/src/intervaldb.c#L1208-L1268)

The existence of these symbols is implicitly assumed, which can cause the build to fail in environments where `time.h` is not automatically included (#56).

## Changes Made

- Added an explicit `#include <time.h>` directive to [`defaults.h`](https://github.com/pyranges/ncls/blob/e3503a6b1b7fa80fb2571d9446a8c2dc80c0f4ea/ncls/src/default.h) to ensure `clock_t` and `CLOCKS_PER_SEC` are always defined.

## Issue Fixed

- Fixes #56