### PR TITLE
Bump cibuildwheel@v2.22.0

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yml
+++ b/.github/workflows/build_and_upload_wheels.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.22.0
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Bump cibuildwheel to v2.22.0 (enables CPython 3.13 build).